### PR TITLE
Update Series.md

### DIFF
--- a/_pages/Series/Series.md
+++ b/_pages/Series/Series.md
@@ -7,6 +7,23 @@ sidebar:
   nav: "docs"
 ---
 
+## 6.01 Prescribed punctuation
+
+<a name="6.01.1">6.01.1</a> Prescribed punctuation for the series elements are found in [0.3.8](/DCRMR/books/general-rules/Prescribed-punctuation/#0.3.10)
+
+## 6.02 Sources of information 
+
+<a name="6.02.1">6.02.1</a> The sources of information for all series elements are the series title page, monograph title page, cover (if issued by the publisher), dust jacket, and the rest of the manifestation, in that order of preference.  If the manifestation has both main series and subseries titles, however, prefer a source containing both titles. Series-like statements present on covers not issued by the publisher usually represent binders’ titles and should be treated as item-level information, if considered important (see Title of item [1.26.X.X](/DCRMR/books/title/Title-of-item/#1.26.X.X))
+
+<a name="6.02.2">6.02.2</a> If the series statement, or any of its elements, is taken from a source other than the series title page, make a note on series statement (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X))
+
+<a name="6.02.3">6.02.3</a> If the series statement appears on both the series title page and the monograph title page, indicate this in a note on series statement (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)), if considered important. Record the text of the latter statement as a second series statement, if the two differ. 
+
+<a name="6.02.4">6.02.4</a> If the series statement appears as a stamp or on a label, transcribe it as found and make a note on series statement to indicate the presence of the stamp or label (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)).
+
+<a name="6.02.5">6.02.5</a>If a series statement is not present in the manifestation, but reference sources provide evidence that the book was issued as part of a publisher’s series, do not record a supplied series statement. Rather, provide the series information in a note on series statement if considered important (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)). Record the series as an authorized access point if considered important for identification or access (see Authorized access point for RDA entity [chapter#.entity#.X.X](/DCRMR/books/chapter-name/Name-of-entity-featured-on-the-page/#chapter#.entity#.X.X)).
+
+
 ## Table of Contents
 {: .no_toc }
 

--- a/_pages/Series/Series.md
+++ b/_pages/Series/Series.md
@@ -9,20 +9,19 @@ sidebar:
 
 ## 6.01 Prescribed punctuation
 
-<a name="6.01.1">6.01.1</a> Prescribed punctuation for the series elements are found in [0.3.8](/DCRMR/books/general-rules/Prescribed-punctuation/#0.3.10)
+<a name="6.01.1">6.01.1</a> Prescribed punctuation for the series elements are found in [0.3.10](/DCRMR/books/general-rules/Prescribed-punctuation/#0.3.10)
 
 ## 6.02 Sources of information 
 
-<a name="6.02.1">6.02.1</a> The sources of information for all series elements are the series title page, monograph title page, cover (if issued by the publisher), dust jacket, and the rest of the manifestation, in that order of preference.  If the manifestation has both main series and subseries titles, however, prefer a source containing both titles. Series-like statements present on covers not issued by the publisher usually represent binders’ titles and should be treated as item-level information, if considered important (see Title of item [1.26.X.X](/DCRMR/books/title/Title-of-item/#1.26.X.X))
+<a name="6.02.1">6.02.1</a> The sources of information for all series elements are the series title page, monograph title page, cover (if issued by the publisher), dust jacket, and the rest of the manifestation, in that order of preference.  If the manifestation has both main series and subseries titles, however, prefer a source containing both titles. Series-like statements present on covers not issued by the publisher usually represent binders’ titles and should be treated as item-level information, if considered important (see [Title of item](/DCRMR/books/title/Title-of-item/) [1.26.X.X](/DCRMR/books/title/Title-of-item/#1.26.X.X)).
 
-<a name="6.02.2">6.02.2</a> If the series statement, or any of its elements, is taken from a source other than the series title page, make a note on series statement (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X))
+<a name="6.02.2">6.02.2</a> If the [series statement](/DCRMR/books/series/Series-statement/), or any of its elements, is taken from a source other than the series title page, make a [note on series statement](/DCRMR/books/series/Note-on-series-statement/) (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)).
 
-<a name="6.02.3">6.02.3</a> If the series statement appears on both the series title page and the monograph title page, indicate this in a note on series statement (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)), if considered important. Record the text of the latter statement as a second series statement, if the two differ. 
+<a name="6.02.3">6.02.3</a> If the [series statement](/DCRMR/books/series/Series-statement/) appears on both the series title page and the monograph title page, indicate this in a [note on series statement](/DCRMR/books/series/Note-on-series-statement/) (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)), if considered important. Record the text of the latter statement as a second [series statement](/DCRMR/books/series/Series-statement/), if the two differ. 
 
-<a name="6.02.4">6.02.4</a> If the series statement appears as a stamp or on a label, transcribe it as found and make a note on series statement to indicate the presence of the stamp or label (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)).
+<a name="6.02.4">6.02.4</a> If the [series statement](/DCRMR/books/series/Series-statement/) appears as a stamp or on a label, transcribe it as found and make a [note on series statement](/DCRMR/books/series/Note-on-series-statement/) to indicate the presence of the stamp or label (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)).
 
-<a name="6.02.5">6.02.5</a>If a series statement is not present in the manifestation, but reference sources provide evidence that the book was issued as part of a publisher’s series, do not record a supplied series statement. Rather, provide the series information in a note on series statement if considered important (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)). Record the series as an authorized access point if considered important for identification or access (see Authorized access point for RDA entity [chapter#.entity#.X.X](/DCRMR/books/chapter-name/Name-of-entity-featured-on-the-page/#chapter#.entity#.X.X)).
-
+<a name="6.02.5">6.02.5</a>If a [series statement](/DCRMR/books/series/Series-statement/) is not present in the manifestation, but reference sources provide evidence that the book was issued as part of a publisher’s series, do not record a supplied [series statement](/DCRMR/books/series/Series-statement/). Rather, provide the series information in a [note on series statement](/DCRMR/books/series/Note-on-series-statement/) if considered important (see [6.28.X.X](/DCRMR/books/series/Note-on-series-statement/#6.28.X.X)). Record the series as an authorized access point if considered important for identification or access (see [Authorized access point for RDA entity](https://beta.rdatoolkit.org/Content/Index?externalId=en-US_ala-9badaad7-0d00-3f72-9ae9-d414344e21a5)).
 
 ## Table of Contents
 {: .no_toc }


### PR DESCRIPTION
Note: The last paragraph in the Sources of information section contains a reference to the blind element "Authorized access point for RDA entity". We haven't decided, yet, whether we will keep this and if so, where it should go in the order of the text.