### PR TITLE
Create Other-title-information-of-series.md

### DIFF
--- a/_pages/Series/Other-title-information-of-series.md
+++ b/_pages/Series/Other-title-information-of-series.md
@@ -1,0 +1,37 @@
+---
+layout: single
+type: docs
+title: Other title information of series
+permalink: series/Other-title-information-of-series/
+sidebar:
+  nav: "docs"
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+## 6.23.1 Element information
+
+<a name="6.23.1.1">6.23.1.1</a> [Link to RDA Toolkit](https://beta.rdatoolkit.org/Content/Index?externalId=en-US_ala-fb17363e-47f7-3220-aef9-256796432ab9){:target="_blank"}
+
+<a name="6.23.1.2">6.23.1.2</a> [Source of information](/DCRMR/series/)
+
+## 6.23.2 RDA definition and scope
+
+<a name="6.23.2.1">6.23.2.1</a> A word, character, or group of words or characters that appears in conjunction with, and is subordinate to, a title of series.
+
+## 6.23.3 General rule
+
+<a name="6.23.3.1">6.23.3.1</a> Transcribe other title information relating to the series, if present, following the series title proper.
+
+>Example:  
+>Other title information of series: <CITE>the best plays of the old dramatists</CITE>  
+>Title proper of series: <CITE>The mermaid series</CITE>  
+
+>Example:  
+>Other title information of series: <CITE>Yo Semite and Pacific Coast</CITE>  
+>Title proper of series: <CITE>Watkins' new boudoir series</CITE>
+


### PR DESCRIPTION
In the examples, the actual element name for the series title proper is now "title of series" and not "title proper of series" but I left it as "title proper of series" because I think it is clearer here, as "title of series" could be understood to include the title proper as well as the other title information of series. Feel free to change this to "Title of series" if you prefer.