### PR TITLE
Update Statement-of-responsibility-relating-to-title-proper.md

### DIFF
--- a/_pages/SOR/Statement-of-responsibility-relating-to-title-proper.md
+++ b/_pages/SOR/Statement-of-responsibility-relating-to-title-proper.md
@@ -96,13 +96,7 @@ sidebar:
 
 ## 2.20.91 Qualifications in statements of responsibility
 
-<a name="2.20.91.1">2.20.91.1</a> Qualifications such as initials indicating membership in societies, academic degrees, and statements of positions held may be omitted from the statement of responsibility, using the mark of omission, unless:
-
-the qualifications are necessary grammatically   
-
-**or**	the qualifications are necessary for identifying the person or are useful in establishing a context for the person’s activity (initials of religious orders, phrases, or adjectives denoting place names, etc.)  
-
-**or**	the statement of responsibility represents the author only by a pseudonym, a descriptive phrase, or nonalphabetic symbols.
+<a name="2.20.91.1">2.20.91.1</a> Qualifications such as initials indicating membership in societies, academic degrees, and statements of positions held may be omitted from the statement of responsibility, using the mark of omission, unless the qualifications are necessary grammatically; or the qualifications are necessary for identifying the person or are useful in establishing a context for the person’s activity (initials of religious orders, phrases, or adjectives denoting place names, etc.); or the statement of responsibility represents the author only by a pseudonym, a descriptive phrase, or nonalphabetic symbols.
 
 ## 2.20.92 Ambiguous statements of responsibility
 
@@ -141,9 +135,7 @@ the qualifications are necessary grammatically
 >Example:  
 ><CITE>by Sir William Dugdale knt. Garter Principal King of Arms ; to which is added, a catalogue of the present nobility of Scotland and Ireland, &c.</CITE>
 
-<a name="2.20.97.1a">2.20.97.1a</a>
-
-*Optionally*, if the phrases are very lengthy and can be abridged without loss of essential information, omit less important words or phrases, using the mark of omission. If the phrases are actually titles of other works given equal prominence with the title of the first work, see [Two or more expressions named on the preferred source of information](/DCRMR/title/Title-proper/#1219-two-or-more-expressions-named-on-the-preferred-source-of-information).
+<a name="2.20.97.2">2.20.97.2</a> *Optionally*, if the phrases are very lengthy and can be abridged without loss of essential information, omit less important words or phrases, using the mark of omission. If the phrases are actually titles of other works given equal prominence with the title of the first work, see [Two or more expressions named on the preferred source of information](/DCRMR/title/Title-proper/#1219-two-or-more-expressions-named-on-the-preferred-source-of-information).
 
 ## 2.20.98 Other statements
 

--- a/_pages/SOR/Statement-of-responsibility-relating-to-title-proper.md
+++ b/_pages/SOR/Statement-of-responsibility-relating-to-title-proper.md
@@ -141,6 +141,8 @@ the qualifications are necessary grammatically
 >Example:  
 ><CITE>by Sir William Dugdale knt. Garter Principal King of Arms ; to which is added, a catalogue of the present nobility of Scotland and Ireland, &c.</CITE>
 
+<a name="2.20.97.1a">2.20.97.1a</a>
+
 *Optionally*, if the phrases are very lengthy and can be abridged without loss of essential information, omit less important words or phrases, using the mark of omission. If the phrases are actually titles of other works given equal prominence with the title of the first work, see [Two or more expressions named on the preferred source of information](/DCRMR/title/Title-proper/#1219-two-or-more-expressions-named-on-the-preferred-source-of-information).
 
 ## 2.20.98 Other statements


### PR DESCRIPTION
Updated as part of the omissions project to move option of Other title information appearing after Statements of responsibility to its own rule.